### PR TITLE
update nuget packages

### DIFF
--- a/AutoSnapper/AutoSnapper.csproj
+++ b/AutoSnapper/AutoSnapper.csproj
@@ -98,9 +98,17 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Reference Include="AWSSDK, Version=2.3.55.0, Culture=neutral, PublicKeyToken=9f476d3089b52be3, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.2.3.55.0\lib\net45\AWSSDK.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.Core.3.7.105.8\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.EC2, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.EC2.3.7.123.6\lib\net45\AWSSDK.EC2.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.S3, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.S3.3.7.103.15\lib\net45\AWSSDK.S3.dll</HintPath>
+    </Reference>
+    <Reference Include="AWSSDK.SimpleDB, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.SimpleDB.3.7.100.79\lib\net45\AWSSDK.SimpleDB.dll</HintPath>
     </Reference>
     <Reference Include="CLAP, Version=4.6.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CLAP.4.6\lib\net35\CLAP.dll</HintPath>
@@ -163,12 +171,15 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="App.example.config" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\AWSSDK.EC2.3.7.123.6\analyzers\dotnet\cs\AWSSDK.EC2.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.S3.3.7.103.15\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.SimpleDB.3.7.100.79\analyzers\dotnet\cs\AWSSDK.SimpleDB.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/AutoSnapper/InstanceManager.cs
+++ b/AutoSnapper/InstanceManager.cs
@@ -144,7 +144,7 @@ namespace AutoSnapper
       };
 
       var ec2Client = Services.GetEc2Client();
-      var statusResult = ec2Client.DescribeInstanceStatus(ec2Request).DescribeInstanceStatusResult;
+      var statusResult = ec2Client.DescribeInstanceStatus(ec2Request);
 
       if (statusResult.InstanceStatuses.Count == 0)
       {

--- a/AutoSnapper/Services.cs
+++ b/AutoSnapper/Services.cs
@@ -83,7 +83,7 @@ namespace AutoSnapper
     /// <returns></returns>
     public static IAmazonEC2 GetEc2Client()
     {
-      var ec2 = AWSClientFactory.CreateAmazonEC2Client();
+      var ec2 = new AmazonEC2Client();
 
       return ec2;
     }
@@ -94,7 +94,7 @@ namespace AutoSnapper
     /// <returns></returns>
     public static IAmazonSimpleDB GetSimpleDbClient()
     {
-      var sdb = AWSClientFactory.CreateAmazonSimpleDBClient();
+      var sdb = new AmazonSimpleDBClient();
 
       return sdb;
     }
@@ -105,7 +105,7 @@ namespace AutoSnapper
     /// <returns></returns>
     public static IAmazonS3 GetS3Client()
     {
-      var s3Client = AWSClientFactory.CreateAmazonS3Client();
+      var s3Client = new AmazonS3Client();
 
       return s3Client;
     }

--- a/AutoSnapper/packages.config
+++ b/AutoSnapper/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK" version="2.3.55.0" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.7.105.8" targetFramework="net45" />
+  <package id="AWSSDK.EC2" version="3.7.123.6" targetFramework="net45" />
+  <package id="AWSSDK.S3" version="3.7.103.15" targetFramework="net45" />
+  <package id="AWSSDK.SimpleDB" version="3.7.100.79" targetFramework="net45" />
   <package id="CLAP" version="4.6" targetFramework="net45" />
   <package id="FluentCommandLineParser" version="1.4.3" targetFramework="net45" />
   <package id="NLog" version="4.3.4" targetFramework="net45" />


### PR DESCRIPTION
Context: AWS is removing the use of all AWS API calls made with TLS 1.0 and TLS 1.1
- update AWS SDK packages version so that it'll use TLS 1.2. See https://aws.amazon.com/blogs/developer/upgrade-aws-sdk-for-net-for-latest-tls-protocols/
- fix compilation errors after upgrading nuget packages